### PR TITLE
Update the config path to ".config/llmariner"

### DIFF
--- a/internal/accesstoken/accesstoken.go
+++ b/internal/accesstoken/accesstoken.go
@@ -39,14 +39,21 @@ func saveToken(token *T) error {
 
 // LoadToken loads the token from a file.
 func LoadToken(ctx context.Context, c *configs.C) (*T, error) {
-	path := TokenFilePath()
-	b, err := os.ReadFile(path)
+	b, err := os.ReadFile(TokenFilePath())
 	if err != nil {
-		if os.IsNotExist(err) {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("read token: %s", err)
+		}
+		// Fall back to the deprecated token file path.
+		b, err = os.ReadFile(deprecatedTokenFilePath())
+		if err != nil {
+			if !os.IsNotExist(err) {
+				return nil, fmt.Errorf("read token: %s", err)
+			}
 			return nil, fmt.Errorf("token file not found. Please run 'llmo auth login'")
 		}
-		return nil, fmt.Errorf("read token: %s", err)
 	}
+
 	var token T
 	if err := yaml.Unmarshal(b, &token); err != nil {
 		return nil, fmt.Errorf("unmarshal token: %s", err)
@@ -66,5 +73,9 @@ func LoadToken(ctx context.Context, c *configs.C) (*T, error) {
 
 // TokenFilePath returns the path to the token file.
 func TokenFilePath() string {
+	return filepath.Join(xdgbasedir.ConfigHome(), "llmariner", "token.yaml")
+}
+
+func deprecatedTokenFilePath() string {
 	return filepath.Join(xdgbasedir.ConfigHome(), "llmo", "token.yaml")
 }

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -100,8 +100,14 @@ func LoadOrCreate() (*C, error) {
 	// Create a config file if it doesn't exists.
 	path := configFilePath()
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		if err := CreateNewConfig(); err != nil {
-			return nil, fmt.Errorf("create default config: %s", err)
+		// Check if the deprecated config file exists.
+		deprecatedPath := deprecatedConfigFilePath()
+		if _, err := os.Stat(deprecatedPath); err == nil {
+			path = deprecatedPath
+		} else {
+			if err := CreateNewConfig(); err != nil {
+				return nil, fmt.Errorf("create default config: %s", err)
+			}
 		}
 	}
 
@@ -195,5 +201,9 @@ func isHTTPURL(s string) bool {
 }
 
 func configFilePath() string {
+	return filepath.Join(xdgbasedir.ConfigHome(), "llmariner", "config.yaml")
+}
+
+func deprecatedConfigFilePath() string {
 	return filepath.Join(xdgbasedir.ConfigHome(), "llmo", "config.yaml")
 }


### PR DESCRIPTION
Still support the old path ".config/llmo" for smooth transition.